### PR TITLE
[INTERNAL] Adds mark for required fields

### DIFF
--- a/specification/index.html
+++ b/specification/index.html
@@ -229,10 +229,10 @@ github_link: specification/index.html
         <li>
             <div>
                 <span class="property-name">
+                    {{name}}
                     {{#if required }}
                         <b class="property-required">*</b>
                     {{/if}}
-                    {{name}}
                 </span> ({{type type}}) - {{summary}}
             </div>
             {{ type-tree type ../used }}

--- a/specification/index.html
+++ b/specification/index.html
@@ -227,8 +227,16 @@ github_link: specification/index.html
     <ul class="{{className}}">
         {{#each properties}}
         <li>
-            <div><span class="property-name">{{name}}</span> ({{type type}}) - {{summary}}</div>
+            <div>
+                <span class="property-name">
+                    {{#if required }}
+                        <b class="property-required">*</b>
+                    {{/if}}
+                    {{name}}
+                </span> ({{type type}}) - {{summary}}
+            </div>
             {{ type-tree type ../used }}
+
         </li>
         {{/each}}
     </ul>

--- a/specification/index.html
+++ b/specification/index.html
@@ -236,7 +236,6 @@ github_link: specification/index.html
                 </span> ({{type type}}) - {{summary}}
             </div>
             {{ type-tree type ../used }}
-
         </li>
         {{/each}}
     </ul>

--- a/theme/_scss/partials/_specification.scss
+++ b/theme/_scss/partials/_specification.scss
@@ -41,6 +41,7 @@ pre.example {
 .specification .property-required {
   color: #c14800;
   font-size: 14px;
+  margin-left: -3px;
 }
 
 .specification ul.arguments li {

--- a/theme/_scss/partials/_specification.scss
+++ b/theme/_scss/partials/_specification.scss
@@ -38,6 +38,11 @@ pre.example {
   border-bottom: 1px dotted #666666;
 }
 
+.specification .property-required {
+  color: #c14800;
+  font-size: 14px;
+}
+
 .specification ul.arguments li {
   margin: 0;
 }


### PR DESCRIPTION
Adds mark for required fields into the specifications page.

Before:

<img width="1248" alt="screen shot 2017-05-18 at 11 43 22 am" src="https://cloud.githubusercontent.com/assets/9554147/26196534/90b8d61a-3bbf-11e7-9e2e-139224abd98d.png">

After:

<img width="1251" alt="screen shot 2017-05-18 at 12 32 14 pm" src="https://cloud.githubusercontent.com/assets/9554147/26198374/124fd2fe-3bc6-11e7-8678-1226586cd9ac.png">